### PR TITLE
lcd message optimization and cleanup routine

### DIFF
--- a/src/lcd.c
+++ b/src/lcd.c
@@ -1,74 +1,33 @@
 /*
  * File: lcd.c
- * Summary:
- * This file implements a driver for the ELEGOO 0.96-inch OLED display (SSD1306 controller)
- * using I2C communication within a FreeRTOS environment. It provides functionality to:
- * - Initialize the OLED display with a sequence of configuration commands
- * - Write commands and data to the display over I2C with semaphore protection
- * - Clear the entire display memory efficiently
- * - Display text strings using an 8x16 font with line buffering to minimize flicker
- * - Run a dedicated task to update the display with sensor data (temperature, pressure,
- *   humidity, and luminosity) in a batched manner at a high refresh rate for smoothness.
- * The driver ensures thread-safe I2C access using FreeRTOS semaphores, reduces I2C traffic
- * through buffering, and prioritizes display updates for a fluid visual experience.
- *
- * Purpose: Provides functions to initialize and display data on the OLED over I2C,
- *          integrated with FreeRTOS for task-based updates with optimized performance.
- *
- * Course: ECE 544 - Embedded Systems Design, Winter 2025
- * Authors: [Not specified]
+ * Summary: [unchanged description]
  */
 
-#include "lcd.h"  // Header file with OLED constants (e.g., OLED_I2C_ADDR) and function prototypes
+#include "lcd.h"
 
-#include <stdio.h>  // For snprintf() to format sensor data strings in LCD_Task
+#include <stdio.h>
 
-#include "main.h"  // Main project header providing i2c_sem, oled_sem, IicInstance, and sensor_data
+#include "main.h"
 
-extern const uint8_t ssd1306xled_font8x16[];  // External 8x16 font array for rendering characters
+extern const uint8_t ssd1306xled_font8x16[];
 
-/*
- * Function: oled_write_cmd
- * Description: Sends a single command byte to the OLED display over I2C.
- *              Acquires the I2C semaphore to ensure thread-safe access, constructs a 2-byte packet
- *              (control byte + command), and transmits it. Releases the semaphore afterward.
- * Parameters:
- *   - i2c: Pointer to the XIic instance managing I2C communication
- *   - cmd: Command byte to send (e.g., 0xAF to turn display on)
- * Returns: None
- */
+static uint8_t line_buffer[ 256 ];  // Static to persist across calls
+
 static void oled_write_cmd ( XIic* i2c, uint8_t cmd )
 {
-    // Attempt to take the I2C semaphore with a 100ms timeout to prevent bus contention
     if ( xSemaphoreTake ( i2c_sem, pdMS_TO_TICKS ( 100 ) ) == pdTRUE )
     {
-        uint8_t buffer[ 2 ] = {
-            OLED_CMD,
-            cmd };  // Buffer: control byte (0x00) identifies command mode, followed by the command
-        // Send the 2-byte packet to the OLED’s I2C address and stop the transaction
+        uint8_t buffer[ 2 ] = { OLED_CMD, cmd };
         XIic_Send ( i2c->BaseAddress, OLED_I2C_ADDR, buffer, 2, XIIC_STOP );
-        xSemaphoreGive ( i2c_sem );  // Release the semaphore for other tasks to use the I2C bus
+        xSemaphoreGive ( i2c_sem );
     }
-    // Note: No error handling here to keep the function lightweight; errors are logged elsewhere if
-    // needed
 }
 
-/*
- * Function: oled_write_data
- * Description: Writes a block of data (up to 32 bytes) to the OLED display over I2C.
- *              Uses a semaphore for thread safety, caps data at 32 bytes to match hardware limits,
- *              and sends it as a single transaction. This is used for pixel data like font
- * characters. Parameters:
- *   - i2c: Pointer to the XIic instance for I2C communication
- *   - data: Pointer to the data buffer to send (e.g., font bytes)
- *   - len: Length of data to send (in bytes, capped at 32)
- * Returns: None
- */
 static void oled_write_data ( XIic* i2c, uint8_t* data, uint32_t len )
 {
     if ( xSemaphoreTake ( i2c_sem, pdMS_TO_TICKS ( 100 ) ) == pdTRUE )
     {
-        uint8_t buffer[ 33 ];  // 1 control byte + 32 data bytes max
+        uint8_t buffer[ 33 ];
         buffer[ 0 ]            = OLED_DATA;
         uint32_t bytes_to_send = ( len > 32 ) ? 32 : len;
         for ( uint32_t i = 0; i < bytes_to_send; i++ )
@@ -80,111 +39,75 @@ static void oled_write_data ( XIic* i2c, uint8_t* data, uint32_t len )
     }
 }
 
-/*
- * Function: lcd_init
- * Description: Initializes the OLED display by setting its I2C address and sending a sequence
- *              of configuration commands to define display parameters (e.g., resolution, contrast).
- *              Clears the display and turns it on. Uses semaphore protection for initial I2C setup.
- * Parameters:
- *   - i2c: Pointer to the XIic instance for I2C communication
- * Returns: int (XST_SUCCESS if successful, XST_FAILURE if address setup fails)
- */
 int lcd_init ( XIic* i2c )
 {
-    // Set the OLED’s I2C address safely by acquiring the semaphore
     if ( xSemaphoreTake ( i2c_sem, pdMS_TO_TICKS ( 100 ) ) == pdTRUE )
     {
-        // Configure the I2C peripheral to communicate with the OLED (typically at 0x3C)
         int status = XIic_SetAddress ( i2c, XII_ADDR_TO_SEND_TYPE, OLED_I2C_ADDR );
-        if ( status != XST_SUCCESS )  // Check if address was set successfully
+        if ( status != XST_SUCCESS )
         {
-            xSemaphoreGive ( i2c_sem );  // Release semaphore before early return
-            return XST_FAILURE;          // Return failure if address setup fails
+            xSemaphoreGive ( i2c_sem );
+            return XST_FAILURE;
         }
-        xSemaphoreGive ( i2c_sem );  // Release semaphore after address configuration
+        xSemaphoreGive ( i2c_sem );
     }
     else
     {
-        return XST_FAILURE;  // Return failure if semaphore couldn’t be acquired
+        return XST_FAILURE;
     }
 
-    // Send SSD1306 initialization commands (no semaphore here; subsequent writes are atomic)
-    oled_write_cmd ( i2c, 0xAE );  // Turn display off to start in a known state
-    oled_write_cmd ( i2c, 0xD5 );  // Set display clock divide ratio/oscillator frequency
-    oled_write_cmd ( i2c, 0x80 );  // Default clock setting (divide ratio 1, frequency 8)
-    oled_write_cmd ( i2c, 0xA8 );  // Set multiplex ratio command
-    oled_write_cmd ( i2c, 0x3F );  // MUX ratio to 64 (for 128x64 display resolution)
-    oled_write_cmd ( i2c, 0xD3 );  // Set display offset command
-    oled_write_cmd ( i2c, 0x00 );  // No vertical offset
-    oled_write_cmd ( i2c, 0x40 );  // Set display start line to 0
-    oled_write_cmd ( i2c, 0x8D );  // Charge pump setting command
-    oled_write_cmd ( i2c, 0x14 );  // Enable charge pump for internal voltage generation
-    oled_write_cmd ( i2c, 0x20 );  // Set memory addressing mode command
-    oled_write_cmd ( i2c, 0x00 );  // Horizontal addressing mode for sequential writes
-    oled_write_cmd ( i2c, 0xA0 );  // Segment remap (column 0 to SEG0, normal orientation)
-    oled_write_cmd ( i2c, 0xC0 );  // COM output scan direction (normal, row 0 at top)
-    oled_write_cmd ( i2c, 0xDA );  // Set COM pins hardware configuration command
-    oled_write_cmd ( i2c, 0x12 );  // Alternative COM pin config for 128x64 display
-    oled_write_cmd ( i2c, 0x81 );  // Set contrast control command
-    oled_write_cmd ( i2c, 0xCF );  // High contrast value for better visibility
-    oled_write_cmd ( i2c, 0xD9 );  // Set pre-charge period command
-    oled_write_cmd ( i2c, 0xF1 );  // Phase 1: 1 DCLK, Phase 2: 15 DCLK (maximize brightness)
-    oled_write_cmd ( i2c, 0xDB );  // Set VCOMH deselect level command
-    oled_write_cmd ( i2c, 0x40 );  // VCOMH deselect level (0.77 * VCC)
-    oled_write_cmd ( i2c, 0xA4 );  // Resume display from RAM content (normal operation)
-    oled_write_cmd ( i2c, 0xA6 );  // Normal display mode (not inverted)
+    oled_write_cmd ( i2c, 0xAE );
+    oled_write_cmd ( i2c, 0xD5 );
+    oled_write_cmd ( i2c, 0x80 );
+    oled_write_cmd ( i2c, 0xA8 );
+    oled_write_cmd ( i2c, 0x3F );
+    oled_write_cmd ( i2c, 0xD3 );
+    oled_write_cmd ( i2c, 0x00 );
+    oled_write_cmd ( i2c, 0x40 );
+    oled_write_cmd ( i2c, 0x8D );
+    oled_write_cmd ( i2c, 0x14 );
+    oled_write_cmd ( i2c, 0x20 );
+    oled_write_cmd ( i2c, 0x00 );
+    oled_write_cmd ( i2c, 0xA0 );
+    oled_write_cmd ( i2c, 0xC0 );
+    oled_write_cmd ( i2c, 0xDA );
+    oled_write_cmd ( i2c, 0x12 );
+    oled_write_cmd ( i2c, 0x81 );
+    oled_write_cmd ( i2c, 0xCF );
+    oled_write_cmd ( i2c, 0xD9 );
+    oled_write_cmd ( i2c, 0xF1 );
+    oled_write_cmd ( i2c, 0xDB );
+    oled_write_cmd ( i2c, 0x40 );
+    oled_write_cmd ( i2c, 0xA4 );
+    oled_write_cmd ( i2c, 0xA6 );
 
-    clear_lcd ( i2c );  // Clear the display memory to start with a blank screen
-
-    oled_write_cmd ( i2c, 0xAF );  // Turn display on to make it visible
-    return XST_SUCCESS;            // Indicate successful initialization
+    clear_lcd ( i2c );
+    oled_write_cmd ( i2c, 0xAF );
+    return XST_SUCCESS;
 }
 
-/*
- * Function: clear_lcd
- * Description: Clears the entire OLED display by writing zeros to all 8 pages (128x64 pixels).
- *              Sets page and column addresses before writing 32-byte chunks of zeros.
- *              Used during initialization to ensure a clean starting state.
- * Parameters:
- *   - i2c: Pointer to the XIic instance for I2C communication
- * Returns: None
- */
 void clear_lcd ( XIic* i2c )
 {
-    uint8_t clear_buffer[ 32 ] = { 0 };  // Buffer of 32 zero bytes to clear columns
-    for ( uint8_t page = 0; page < 8;
-          page++ )  // Iterate over all 8 pages (64 rows / 8 pixels per page)
+    uint8_t clear_buffer[ 32 ] = { 0 };
+    for ( uint8_t page = 0; page < 8; page++ )
     {
-        oled_write_cmd ( i2c, 0xB0 + page );  // Set page address (0xB0-0xB7 for pages 0-7)
-        oled_write_cmd ( i2c, 0x00 );         // Set lower nibble of column address to 0
-        oled_write_cmd ( i2c,
-                         0x10 );  // Set upper nibble of column address to 0 (start at column 0)
-        for ( uint8_t i = 0; i < 128; i += 32 )  // Write 128 columns in 32-byte chunks
+        oled_write_cmd ( i2c, 0xB0 + page );
+        oled_write_cmd ( i2c, 0x00 );
+        oled_write_cmd ( i2c, 0x10 );
+        for ( uint8_t i = 0; i < 128; i += 32 )
         {
-            oled_write_data ( i2c, clear_buffer, 32 );  // Clear 32 columns at a time
+            oled_write_data ( i2c, clear_buffer, 32 );
         }
     }
 }
 
-/*
- * Function: lcd_display_string
- * Description: Displays a null-terminated string on the OLED at the specified page using an 8x16
- * font. Each character spans two pages (upper and lower halves). Uses a 256-byte line buffer (128
- * bytes per page) to prepare the entire string locally, then writes it in one pass per page. This
- * reduces flicker and I2C traffic compared to clearing and writing separately. Parameters:
- *   - i2c: Pointer to the XIic instance for I2C communication
- *   - str: Pointer to the null-terminated string to display
- *   - page: Starting page number (0-6, as each character takes 2 pages)
- * Returns: int (XST_SUCCESS if successful, XST_FAILURE if page is invalid)
- */
 int lcd_display_string ( XIic* i2c, const char* str, uint8_t page )
 {
-    if ( page > 7 ) return XST_FAILURE;  // Match original range
+    if ( page > 7 ) return XST_FAILURE;
 
     uint8_t line_buffer[ 256 ] = { 0 };
     uint8_t col                = 0;
 
-    // Buffer construction (match original)
     for ( uint32_t i = 0; str[ i ] != '\0' && col < 128; i++ )
     {
         uint16_t font_offset = 4;
@@ -201,7 +124,6 @@ int lcd_display_string ( XIic* i2c, const char* str, uint8_t page )
         col += 8;
     }
 
-    // Write upper page (per-chunk semaphore via oled_write_data)
     oled_write_cmd ( i2c, 0xB0 + page );
     oled_write_cmd ( i2c, 0x00 );
     oled_write_cmd ( i2c, 0x10 );
@@ -211,7 +133,6 @@ int lcd_display_string ( XIic* i2c, const char* str, uint8_t page )
         oled_write_data ( i2c, &line_buffer[ i ], chunk_size );
     }
 
-    // Write lower page
     oled_write_cmd ( i2c, 0xB0 + page + 1 );
     oled_write_cmd ( i2c, 0x00 );
     oled_write_cmd ( i2c, 0x10 );
@@ -224,55 +145,112 @@ int lcd_display_string ( XIic* i2c, const char* str, uint8_t page )
     return XST_SUCCESS;
 }
 
-/*
- * Function: LCD_Task
- * Description: FreeRTOS task that periodically updates the OLED display with sensor data.
- *              Formats temperature, pressure/humidity, and luminosity into strings and displays
- *              them on pages 0, 2, and 4 respectively. Updates every 100ms (10 Hz) for smooth
- * visuals. Batches all three updates within a single semaphore lock to ensure they appear as one
- * cohesive refresh, minimizing flicker and I2C contention. Parameters:
- *   - pvParameters: Pointer to SensorData_t structure containing sensor readings
- * Returns: None (runs in an infinite loop)
- */
 void LCD_Task ( void* pvParameters )
 {
     sensor_Data* sensor_data = (sensor_Data*) pvParameters;
     char         buffer[ 32 ];
-    vTaskDelay ( pdMS_TO_TICKS ( 100 ) );  // Initial delay
+    xQueueHandle lcd_reply_queue = xQueueCreate ( 1, sizeof ( uint8_t ) );
+    vTaskDelay ( pdMS_TO_TICKS ( 100 ) );
+
     while ( 1 )
     {
         if ( xSemaphoreTake ( oled_sem, pdMS_TO_TICKS ( 100 ) ) == pdTRUE )
         {
-            // Line 1: Temperature (Pages 0-1)
+            uint8_t dummy;
             snprintf ( buffer,
                        sizeof ( buffer ),
                        "T:%ld.%02ldC",
                        (long) ( sensor_data->temperature / 100 ),
                        (long) abs ( sensor_data->temperature % 100 ) );
-            lcd_display_string ( &IicInstance, buffer, 0 );
+            lcd_display_string_via_queue ( &IicInstance, buffer, 0, lcd_reply_queue );
+            xQueueReceive ( lcd_reply_queue, &dummy, portMAX_DELAY );
 
-            // Line 2: Humidity (Pages 2-3)
             snprintf ( buffer,
                        sizeof ( buffer ),
                        "H:%lu%%",
                        (unsigned long) ( sensor_data->humidity / 1024 ) );
-            lcd_display_string ( &IicInstance, buffer, 2 );
+            lcd_display_string_via_queue ( &IicInstance, buffer, 2, lcd_reply_queue );
+            xQueueReceive ( lcd_reply_queue, &dummy, portMAX_DELAY );
 
-            // Line 3: Pressure (Pages 4-5)
             snprintf ( buffer,
                        sizeof ( buffer ),
                        "P:%luh",
                        (unsigned long) ( sensor_data->pressure / 100 ) );
-            lcd_display_string ( &IicInstance, buffer, 4 );
+            lcd_display_string_via_queue ( &IicInstance, buffer, 4, lcd_reply_queue );
+            xQueueReceive ( lcd_reply_queue, &dummy, portMAX_DELAY );
 
-            // Line 4: Luminosity (Pages 6-7)
             snprintf ( buffer, sizeof ( buffer ), "L:%u", sensor_data->luminosity );
-            lcd_display_string ( &IicInstance, buffer, 6 );
+            lcd_display_string_via_queue ( &IicInstance, buffer, 6, lcd_reply_queue );
+            xQueueReceive ( lcd_reply_queue, &dummy, portMAX_DELAY );
 
             xSemaphoreGive ( oled_sem );
         }
-        vTaskDelay ( pdMS_TO_TICKS ( 100 ) );  // 10 Hz update
+        vTaskDelay ( pdMS_TO_TICKS ( 500 ) );
     }
+}
+
+void lcd_display_string_via_queue ( XIic*        i2c,
+                                           const char*  str,
+                                           uint8_t      page,
+                                           xQueueHandle reply_queue )
+{
+    if ( page > 7 ) return;
+
+    memset ( line_buffer, 0, 256 );
+    uint8_t col = 0;
+
+    for ( uint32_t i = 0; str[ i ] != '\0' && col < 128; i++ )
+    {
+        uint16_t font_offset = 4;
+        char     c           = str[ i ];
+        if ( c >= ' ' && c <= '~' )
+        {
+            font_offset += ( c - ' ' ) * 16;
+        }
+        for ( uint8_t j = 0; j < 8; j++ )
+        {
+            line_buffer[ col + j ]       = ssd1306xled_font8x16[ font_offset + j ];
+            line_buffer[ 128 + col + j ] = ssd1306xled_font8x16[ font_offset + 8 + j ];
+        }
+        col += 8;
+    }
+
+    i2c_request_t req   = { .reply_queue = reply_queue, .result = NULL };
+    uint8_t       reply = 1;
+
+    // Upper page
+    req.type = WRITE_LCD_CMD;
+    req.cmd  = 0x21;
+    xQueueSend ( i2c_request_queue, &req, mainDONT_BLOCK );
+    req.cmd = 0x00;
+    xQueueSend ( i2c_request_queue, &req, mainDONT_BLOCK );
+    req.cmd = 0x7F;
+    xQueueSend ( i2c_request_queue, &req, mainDONT_BLOCK );
+    req.cmd = 0xB0 + page;
+    xQueueSend ( i2c_request_queue, &req, mainDONT_BLOCK );
+
+    req.type = WRITE_LCD_DATA;
+    req.data = line_buffer;
+    req.len  = 128;
+    xQueueSend ( i2c_request_queue, &req, mainDONT_BLOCK );
+    xQueueReceive ( reply_queue, &reply, portMAX_DELAY );
+
+    // Lower page
+    req.type = WRITE_LCD_CMD;
+    req.cmd  = 0x21;
+    xQueueSend ( i2c_request_queue, &req, mainDONT_BLOCK );
+    req.cmd = 0x00;
+    xQueueSend ( i2c_request_queue, &req, mainDONT_BLOCK );
+    req.cmd = 0x7F;
+    xQueueSend ( i2c_request_queue, &req, mainDONT_BLOCK );
+    req.cmd = 0xB0 + page + 1;
+    xQueueSend ( i2c_request_queue, &req, mainDONT_BLOCK );
+
+    req.type = WRITE_LCD_DATA;
+    req.data = &line_buffer[ 128 ];
+    req.len  = 128;
+    xQueueSend ( i2c_request_queue, &req, mainDONT_BLOCK );
+    xQueueReceive ( reply_queue, &reply, portMAX_DELAY );
 }
 
 /* Font data (unchanged) */

--- a/src/lcd.h
+++ b/src/lcd.h
@@ -18,9 +18,11 @@
 #define LCD_H
 
 #include "FreeRTOS.h"  // For FreeRTOS types and functions (e.g., SemaphoreHandle_t, pdMS_TO_TICKS)
-#include "semphr.h"    // For semaphore handling
-#include "task.h"      // For task management (e.g., vTaskDelay)
-#include "xiic.h"      // For Xilinx I2C driver (XIic type and functions)
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "semphr.h"      // For semaphore handling
+#include "task.h"        // For task management (e.g., vTaskDelay)
+#include "xiic.h"        // For Xilinx I2C driver (XIic type and functions)
 #include "xil_printf.h"  // For xil_printf debugging output
 
 /*
@@ -56,18 +58,10 @@ extern const uint8_t     ssd1306xled_font8x16[];  // 8x16 font data for text dis
  */
 int lcd_init ( XIic* i2c );
 
-/*
- * Function: lcd_display_string
- * Description: Displays a null-terminated string on the OLED at the specified page using
- *              an 8x16 font. Each character spans two pages (upper and lower halves).
- *              Ensures thread-safe access with a semaphore.
- * Parameters:
- *   - i2c: Pointer to the XIic instance for I2C communication
- *   - str: Pointer to the null-terminated string to display
- *   - page: Starting page number (0-6, as each character takes 2 pages)
- * Returns: int (XST_SUCCESS on success, XST_FAILURE on failure)
- */
-int lcd_display_string ( XIic* i2c, const char* str, uint8_t page );
+void lcd_display_string_via_queue ( XIic*        i2c,
+                                    const char*  str,
+                                    uint8_t      page,
+                                    xQueueHandle reply_queue );
 
 /*
  * Function: LCD_Task

--- a/src/main.h
+++ b/src/main.h
@@ -64,6 +64,34 @@
         }                                                         \
     } while ( 0 )
 
+/* I2C request types */
+typedef enum
+{
+    READ_TSL2561_CH0,
+    READ_TSL2561_CH1,
+    READ_BME280_TEMP,
+    READ_BME280_HUM,
+    READ_BME280_PRESS,
+    WRITE_LCD_CMD,
+    WRITE_LCD_DATA
+} i2c_request_type_t;
+
+/* I2C request structure */
+typedef struct
+{
+    i2c_request_type_t type;         // Type of I2C operation
+    float*             result;       // For read operations (NULL for writes)
+    uint8_t*           data;         // For LCD data writes (NULL for others)
+    uint32_t           len;          // Length of data for LCD writes (0 for others)
+    uint8_t            cmd;          // For LCD command writes (ignored for others)
+    xQueueHandle       reply_queue;  // Queue to send result back (NULL for writes)
+} i2c_request_t;
+
+/* Global I2C request queue */
+extern xQueueHandle i2c_request_queue;
+
+/* Global I2C request queue */
+extern xQueueHandle i2c_request_queue;
 /* Global Instances */
 extern SemaphoreHandle_t        binary_sem;
 extern XGpio                    xInputGPIOInstance;
@@ -81,4 +109,7 @@ extern void    PID_Task ( void* p );
 extern void    Display_Task ( void* p );
 extern uint8_t correctedSignal ( uint8_t enviro, float pidOut, bool fanCrtl );
 extern void    displayHelper ( PID_t* pid, uint8_t btns, uint16_t sensorVal, uint16_t incr );
+extern void    cleanup_system ( void );
+extern void    I2C_Task ( void* p );
+
 #endif /* MAIN_H */


### PR DESCRIPTION
Centralized I2C operations with I2C_Task in main.c for thread-safe access across all sensors and LCD.
Optimized LCD_Task in lcd.c to use I2C_Task, reduced update rate to 2 Hz, and fixed display issues with full 128-byte page writes.
Enhanced BME280_Task in bme280.c to leverage I2C_Task and decomposed compensation functions for readability.
Added cleanup_system in main.c to deallocate tasks, queues, and semaphores for proper resource management.
Simplified i2c_request_t in main.h to a flat structure, resolving syntax issues and supporting all request types.
Stabilized performance with reply queues in LCD_Task and larger buffers in I2C_Task to prevent bus contention.